### PR TITLE
Mirror main to master

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,11 @@
+name: Mirror Branch main to master
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  mirror-to-master:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: zofrex/mirror-branch@v1.0.2


### PR DESCRIPTION
This will more easily support older versions of the okta-cli while folks are updating to a newer version
(in the near future we can delete this workflow and the master branch)